### PR TITLE
.prepend() bug issue #34

### DIFF
--- a/src/prepend.js
+++ b/src/prepend.js
@@ -7,14 +7,18 @@ public.prototype.prepend = function(content)
     // Loop through current elements
     this.forEach(this.elements, function(element)
     {
+        var child;
         if(typeof content == "string")
         {
-            element.innerHTML = content + element.innerHTML;
+            var range = document.createRange();
+            range.selectNode(document.body);
+            child = range.createContextualFragment(content);
         }
         else
         {
-            element.insertBefore(content.cloneNode(true), element.firstChild);
+            child = content.cloneNode(true);
         }
+        element.insertBefore(child, element.firstChild);
     });
 
     return this;

--- a/test/append.js
+++ b/test/append.js
@@ -2,6 +2,7 @@ QUnit.test("Appending strings and elements", function(assert)
 {
     var el = $('.append-child').el[0];
     var appendBtn = document.createElement('button');
+    appendBtn.className = 'appended-button-class';
     var evt = new Event('click');
     var output = [];
 
@@ -24,4 +25,10 @@ QUnit.test("Appending strings and elements", function(assert)
     el.dispatchEvent(evt);
     assert.equal(output.length, 3, 'Check if event remains bound after appending an element');
     assert.equal($('.append button').el.length, 2, 'Check if the button was actually appended');
+    assert.equal($('.append').el[0].lastChild.className, 'appended-button-class', 'Check if appended button is last child');
+
+    $('.append-html-append').append('<p class="string-html">Appending an HTML string</p>');
+    assert.equal($('.append-html-append').el[0].textContent.match('Appending an HTML string').length, 1, 'Check if text of HTML was appended');
+    assert.equal($('.append-html-append .string-html').el.length, 1, 'Check if HTML was appended as HTML');
+    assert.equal($('.append-html-append').el[0].lastChild.className, 'string-html', 'Check if appended HTML is last child');
 });

--- a/test/prepend.js
+++ b/test/prepend.js
@@ -1,0 +1,34 @@
+QUnit.test("Prepending strings and elements", function(assert)
+{
+    var el = $('.prepend-child').el[0];
+    var prependBtn = document.createElement('button');
+    prependBtn.className = 'prepended-button-class';
+    var evt = new Event('click');
+    var output = [];
+
+    el.addEventListener('click', function()
+    {
+        output.push('prepend test');
+    });
+
+    $('.prepend').prepend('prepending a string!');
+    el.dispatchEvent(evt);
+    assert.equal(output.length, 1, 'Check if event remains bound after prepending a string');
+    assert.equal($('.prepend').el[0].textContent.match('prepending a string').length, 1, 'Check if the string was actually prepended');
+
+    $('.prepend').prepend('<u>Prepending some HTML</u>');
+    el.dispatchEvent(evt);
+    assert.equal(output.length, 2, 'Check if event remains bound after prepending html');
+    assert.equal($('.prepend').el[0].textContent.match('Prepending some HTML').length, 1, 'Check if the HTML was actually prepended');
+
+    $('.prepend').prepend(prependBtn);
+    el.dispatchEvent(evt);
+    assert.equal(output.length, 3, 'Check if event remains bound after prepending an element');
+    assert.equal($('.prepend button').el.length, 2, 'Check if the button was actually prepended');
+    assert.equal($('.prepend').el[0].firstChild.className, 'prepended-button-class', 'Check if prepended button is first child');
+
+    $('.prepend-html-prepend').prepend('<p class="string-html">Prepending an HTML string</p>');
+    assert.equal($('.prepend-html-prepend').el[0].textContent.match('Prepending an HTML string').length, 1, 'Check if text of HTML was prepended');
+    assert.equal($('.prepend-html-prepend .string-html').el.length, 1, 'Check if HTML was appended as HTML');
+    assert.equal($('.prepend-html-prepend').el[0].firstChild.className, 'string-html', 'Check if prepended HTML is first child');
+});

--- a/test/test-page.html
+++ b/test/test-page.html
@@ -38,6 +38,13 @@
             <!-- Testing .append() -->
             <div class="append">
                 <button class="append-child"></button>
+                <div class="append-html-append"></div>
+            </div>
+
+            <!-- Testing .prepend() -->
+            <div class="prepend">
+                <button class="prepend-child"></button>
+                <div class="prepend-html-prepend"></div>
             </div>
         </div>
 
@@ -48,5 +55,6 @@
         <script src="removeClass.js"></script>
         <script src="value.js"></script>
         <script src="append.js"></script>
+        <script src="prepend.js"></script>
     </body>
 </html>


### PR DESCRIPTION
- Fix bug with unbound event listeners for .prepend() in the same way .append() was addressed
- Add tests for prepend analogous to append
- Add test to tell if html string was actually added as html
- Add tests to tell if prepend adds before, append after

Does it make sense at this point to extract out the fragment creation | cloneNode logic as a private function?  It may prove useful elsewhere.  On that note, should the prepend/append tests be cleaned up by leveraging some helper functions for test setup/execution?
